### PR TITLE
Support pull_request in branch handling

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,7 +69,7 @@ runs:
     - name: Create or Locate Container
       id: manage-container
       shell: bash
-      if: ${{ (github.event_name == 'create' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')) && steps.should-run.outputs.should_run == 'true' }}
+      if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'create' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')) && steps.should-run.outputs.should_run == 'true' }}
       env:
         API_URL: ${{ inputs.api_url }}
         API_KEY: ${{ inputs.api_key }}


### PR DESCRIPTION
Issue: https://github.com/mieweb/launchpad/issues/5

Add handling for pull_request events: expose GITHUB_HEAD_REF and use it to set TARGET_BRANCH for PRs. Update workflow conditionals so the Create/Locate Container step runs for pull_request events (except when action is closed), and treat pull_request closed as a branch deletion for the Container Deletion step. This enables the action to properly create and clean up containers for pull request workflows. Also is conjunction with https://github.com/mieweb/opensource-server/issues/196 