### PR TITLE
Normalize template tags, improve error output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,13 +87,12 @@ runs:
         CONTAINER_NAME=${CONTAINER_NAME,,}
         CONTAINER_NAME=$(echo "$CONTAINER_NAME" | sed 's/[^a-z0-9-]/-/g')
 
-        # Truncate to 63 chars (DNS label limit): keep first half, append 8-char hash of second half
+        # Truncate to 63 chars (DNS label limit): keep first 54 chars, append dash + 8-char hash of the rest
         if [ ${#CONTAINER_NAME} -gt 63 ]; then
-          HALF=$(( ${#CONTAINER_NAME} / 2 ))
-          FIRST_HALF="${CONTAINER_NAME:0:$HALF}"
-          SECOND_HALF="${CONTAINER_NAME:$HALF}"
-          NAME_HASH=$(printf '%s' "$SECOND_HALF" | sha256sum | cut -c1-8)
-          CONTAINER_NAME="${FIRST_HALF:0:55}${NAME_HASH}"
+          PART1="${CONTAINER_NAME:0:54}"
+          PART2="${CONTAINER_NAME:54}"
+          NAME_HASH=$(printf '%s' "$PART2" | sha256sum | cut -c1-8)
+          CONTAINER_NAME="${PART1}-${NAME_HASH}"
         fi
 
         echo "container_name=$CONTAINER_NAME" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -87,6 +87,15 @@ runs:
         CONTAINER_NAME=${CONTAINER_NAME,,}
         CONTAINER_NAME=$(echo "$CONTAINER_NAME" | sed 's/[^a-z0-9-]/-/g')
 
+        # Truncate to 63 chars (DNS label limit): keep first half, append 8-char hash of second half
+        if [ ${#CONTAINER_NAME} -gt 63 ]; then
+          HALF=$(( ${#CONTAINER_NAME} / 2 ))
+          FIRST_HALF="${CONTAINER_NAME:0:$HALF}"
+          SECOND_HALF="${CONTAINER_NAME:$HALF}"
+          NAME_HASH=$(printf '%s' "$SECOND_HALF" | sha256sum | cut -c1-8)
+          CONTAINER_NAME="${FIRST_HALF:0:55}${NAME_HASH}"
+        fi
+
         echo "container_name=$CONTAINER_NAME" >> $GITHUB_OUTPUT
         echo "Managing Container: $CONTAINER_NAME"
 

--- a/action.yml
+++ b/action.yml
@@ -90,6 +90,14 @@ runs:
         echo "container_name=$CONTAINER_NAME" >> $GITHUB_OUTPUT
         echo "Managing Container: $CONTAINER_NAME"
 
+        # Normalize template tag: replace slashes with hyphens to match docker/metadata-action behavior
+        if [[ "$TEMPLATE_NAME" == *:* ]]; then
+          TEMPLATE_BASE="${TEMPLATE_NAME%:*}"
+          TEMPLATE_TAG="${TEMPLATE_NAME##*:}"
+          TEMPLATE_TAG=$(echo "$TEMPLATE_TAG" | sed 's|/|-|g')
+          TEMPLATE_NAME="${TEMPLATE_BASE}:${TEMPLATE_TAG}"
+        fi
+
         # 2. Check for existing container
         echo "Querying API: $API_URL/sites/$SITE_ID/containers?hostname=$CONTAINER_NAME"
 
@@ -202,8 +210,12 @@ runs:
           fi
 
           if [ "$JOB_STATUS" == "failed" ] || [ "$JOB_STATUS" == "error" ] || [ "$JOB_STATUS" == "cancelled" ]; then
-            echo "::error::Job entered '$JOB_STATUS' state."
-            echo "    Full response: $RESPONSE_BODY"
+            FAILURE_REASON=$(echo "$RESPONSE_BODY" | jq -r '.error // .message // .reason // empty')
+            if [ -n "$FAILURE_REASON" ]; then
+              echo "::error::Job entered '$JOB_STATUS' state: $FAILURE_REASON"
+            else
+              echo "::error::Job entered '$JOB_STATUS' state. Full response: $RESPONSE_BODY"
+            fi
             echo "FAILED=1" >> $GITHUB_ENV
             exit 1
           fi
@@ -262,7 +274,8 @@ runs:
         echo ""
 
         if [ "$CONTAINER_STATUS" != "running" ]; then
-          echo "::warning::Container status is '$CONTAINER_STATUS', expected 'running'."
+          echo "::error::Container status is '$CONTAINER_STATUS', expected 'running'."
+          exit 1
         fi
 
         echo "container_status=$CONTAINER_STATUS" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Resolves the following issues
https://github.com/mieweb/launchpad/issues/10
https://github.com/mieweb/launchpad/issues/9
https://github.com/mieweb/launchpad/issues/8
https://github.com/mieweb/launchpad/issues/3

1. Normalize TEMPLATE_NAME tags by replacing slashes with hyphens to match docker/metadata-action behavior. 
2. Improve job-failure logging by extracting a failure reason from the API response (via jq) and printing it when available, otherwise print the full response. 
3. Harden container checks: treat non-running container status as an error and exit non-zero instead of emitting only a warning.