### PR TITLE
Validate required inputs in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,20 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Validate Required Inputs
+      shell: bash
+      env:
+        API_KEY: ${{ inputs.api_key }}
+        API_URL: ${{ inputs.api_url }}
+      run: |
+        missing=()
+        [ -z "$API_KEY" ] && missing+=("api_key")
+        [ -z "$API_URL" ] && missing+=("api_url")
+        if [ ${#missing[@]} -gt 0 ]; then
+          echo "::error::Missing required input(s): ${missing[*]}"
+          exit 1
+        fi
+
     - name: Check if action should run
       shell: bash
       id: should-run


### PR DESCRIPTION
Resolves: https://github.com/mieweb/opensource-server/issues/278

Add a composite action step that validates required inputs (api_key and api_url) before other steps run. The new Bash step checks for missing inputs, logs an error, and exits with non-zero status if any are absent, preventing the action from proceeding with incomplete configuration. While it does not directly fix a failed run, it will give stronger logging as to what  is missing to complete the build image operation, especially if it is related to a user error where a secret is not properly linked to the action run. 