### PR TITLE
Handle container creation 409 conflict

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -194,6 +194,12 @@ runs:
             echo "container_id=$NEW_ID" >> $GITHUB_OUTPUT
             echo "job_id=$JOB_ID" >> $GITHUB_OUTPUT
             echo "container_created=true" >> $GITHUB_OUTPUT
+          elif [ "$CREATE_CODE" -eq 409 ]; then
+            # Container already exists (race condition with concurrent workflow)
+            EXISTING_ID=$(echo "$CREATE_BODY" | jq -r '.container.id // empty')
+            echo "Container already exists (conflict). Using existing container ID: $EXISTING_ID"
+            echo "container_id=$EXISTING_ID" >> $GITHUB_OUTPUT
+            echo "container_ready=true" >> $GITHUB_OUTPUT
           else
             echo "::error::Failed to create container. HTTP: $CREATE_CODE"
             echo "    Response: $CREATE_BODY"


### PR DESCRIPTION
Issue: https://github.com/mieweb/launchpad/issues/15
Related: https://github.com/mieweb/opensource-server/pull/318
Add handling for HTTP 409 (conflict) when creating a container in action.yml. If the API returns 409, extract the existing container ID from the response using jq, log a message, and emit container_id and container_ready outputs so concurrent workflow race conditions reuse the existing container. Other non-success responses keep the existing error handling.

Fixes Applied

Before starting Proxmox creation: checks if the job was cancelled and aborts
After Proxmox creation completes: re-verifies the DB record exists; if deleted, destroys the orphaned Proxmox container and exits
routers/containers.js 
Two changes:

POST handler: Checks for existing container with same (siteId, hostname) using SELECT ... FOR UPDATE within the transaction. Returns HTTP 409 if one already exists, preventing the race at the application level
DELETE handler: Cancels any pending/running creation job before destroying the container record, so the creation script knows to abort

Handles HTTP 409 (conflict) response from the POST endpoint gracefully, treats it as "container already exists" and uses the existing container instead of failing